### PR TITLE
Fix a busted link to Kernel in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is an implementation of a language resembling [https://web.cs.wpi.edu/~jshutt/kernel.html](Kernel). The implementation includes an interpreter and soon a compiler.
+This is an implementation of a language resembling [Kernel](https://web.cs.wpi.edu/~jshutt/kernel.html). The implementation includes an interpreter and soon a compiler.
 
 # How to use
 


### PR DESCRIPTION
Howdy, I am an internet rando / Lisp enjoyer / helpful README gremlin who found this repo interesting and was poking around 👋 

Noticed that the link to Shutt's Kernel page was broken, so figured I'd PR a fix.